### PR TITLE
Update version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The package hasn't been published to PyPI yet, and may never be, as its primary
 purpose doesn't require it. However you can install it through git:
 
 ```shell script
-pip install git+git://github.com/AleksaC/hadolint-py.git@v1.19.0
+pip install git+git://github.com/AleksaC/hadolint-py.git@v2.10.0
 ```
 
-To install another version simply replace the v1.19.0 with the version you want.
+To install another version simply replace the v2.10.0 with the version you want.
 
 ### With pre-commit
 
@@ -35,7 +35,7 @@ Example `.pre-commit-config.yaml` with rules `DL3025` and `DL3018` excluded:
 ```yaml
 repos:
   - repo: https://github.com/AleksaC/hadolint-py
-    rev: v1.19.0
+    rev: v2.10.0
     hooks:
       - id: hadolint
         args: [--ignore, DL3025, --ignore, DL3018]


### PR DESCRIPTION
Update to latest tag: v2.10.0

I used the version in the README and it did not work. It found no files to check:

```
$ pre-commit run -a
Hadolint.............................................(no files to check)Skipped
````

When I used the new version, it worked. Therefore, to prevent this issue for other users, this should be updated.