### PR TITLE
chore: fix add-new-versions for Darwin

### DIFF
--- a/add-new-versions.py
+++ b/add-new-versions.py
@@ -176,6 +176,8 @@ def get_archives(repo: str, version: Version) -> dict[str, tuple[str, str]]:
         )
 
         os_normalized, arch_normalized = os.lower(), arch.lower()
+        if os_normalized == "macos":
+            os_normalized = "darwin"
 
         if os_normalized not in OS or arch_normalized not in ARCH:
             raise ValueError("Unsupported plaform!", os, arch)


### PR DESCRIPTION
The `darwin` binaries are named `macos` since [v2.13.1](https://github.com/hadolint/hadolint/releases/tag/v2.13.1).

Closes #14